### PR TITLE
Strip off ANSI Escapes from g:find_files_findprg command output

### DIFF
--- a/after/ftplugin/findfiles.vim
+++ b/after/ftplugin/findfiles.vim
@@ -29,7 +29,9 @@ function s:open_file(is_preview)
 
   " Opew a new split, and file under the cursor in the split
   exe g:find_files_buf_preview_command
-  norm gf
+
+  " Remove ansi escape sequences for shell output that is colored
+  exe "silent! edit " . substitute(substitute(getline('.'), '\[0m', '', 'g'), '.*\.\/', '.\/', 'g')
   let w:find_files_is_preview_win = 1
 
   " If opened in a preview mode, keep focus in filelist window

--- a/after/ftplugin/findfiles.vim
+++ b/after/ftplugin/findfiles.vim
@@ -31,7 +31,10 @@ function s:open_file(is_preview)
   exe g:find_files_buf_preview_command
 
   " Remove ansi escape sequences for shell output that is colored
-  exe "silent! edit " . substitute(substitute(getline('.'), '\[0m', '', 'g'), '.*\.\/', '.\/', 'g')
+  if !exists('s:find_files_cwd')
+    let s:find_files_cwd = getcwd()
+  endif
+  exe "silent! edit " . s:find_files_cwd . substitute(substitute(getline('.'), '\[0m', '', 'g'), '.*\.\/', '\/', 'g')
   let w:find_files_is_preview_win = 1
 
   " If opened in a preview mode, keep focus in filelist window


### PR DESCRIPTION
Output from `g:find_files_findprg` command may contain AnsiEsc sequence (e.g.`^[[0m^[[32m./output/dir^[[0m`). This pull request makes `vim-find-files` able to open files/directories in the "File List" buffer with AnsiEsc sequence in it (by stripping off the ansi escape sequence before following the link to the file).

This allows `vim-find-files` to have output being colored inside Vim using [AnsiEsc](https://github.com/powerman/vim-plugin-AnsiEsc) plugin by adding the following setting to `.vimrc`:

```vim
function! SetHighlightFindFiles()
    if &filetype ==# 'findfiles'
        AnsiEsc
    endif
endfunction

augroup my_find_files_customization
    autocmd! FileType findfiles :call SetHighlightFindFiles()
augroup END " my_find_files_customization
```

And here is the result (with "File List" buffer with syntax highlight using [AnsiEsc](https://github.com/powerman/vim-plugin-AnsiEsc)):

![Screenshot at Jul 26 21-43-13](https://user-images.githubusercontent.com/874795/88504290-236c7100-cf89-11ea-96e0-e0c1932a6e70.png)


